### PR TITLE
Update App.svelte

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -41,7 +41,7 @@
     const containsNonAscii_text2 = /[^\x00-\x7F]/.test(text2);
 
     const leftPadding = (text1 == "")?15:20;       
-    const rightPadding = (text2 == "")?-25:-10;
+    const rightPadding = (text2 == "")?-25:-12;   
     const bottomPadding = -30;  
     const topPadding = containsNonAscii_text2?55:45;     
     const totalTextWidth = text1Metrics.width + text2Metrics.width + spacing;
@@ -108,7 +108,7 @@
     const chatX = x + leftPadding + text1Metrics.width + spacing;
     const chatBoxHeight = containsNonAscii_text2?(textHeight/1.35):(textHeight/1.45);
     const chatY = bubbleCenterY - chatBoxHeight/2 - 5;
-    const chatBoxWidth = text2Metrics.width + 12;
+    const chatBoxWidth = text2Metrics.width + 8;
     const chatCornerRadius = 12;
 
     if(text2 != ""){


### PR DESCRIPTION
## Summary of changes
- Improved consistency of the design with the original
- Made possible of creating short version logo (Also to avoid the empty black rect is generated when the second text is empty)
- Made round the tail in the logo
- Made adjust the black rect size depending the character type with design improvements (the original is only uses alphabet so it needed to adjust to when use にほんご)
- Added some comments in `App.svelte` for understanding code as possible (They ain't annoying the reader I guess)

## Images
![image](https://github.com/user-attachments/assets/31b6ffe5-c1b1-4c43-b7fd-befae1985a4d)
![image](https://github.com/user-attachments/assets/01837332-931d-4848-933b-543fec79652f)
![image](https://github.com/user-attachments/assets/4a052d39-e155-4c84-8375-b930c17483d0)
![image](https://github.com/user-attachments/assets/6d2c6bd8-d303-4de8-9933-019ebd3d5a26)

